### PR TITLE
Fixes crash on inject

### DIFF
--- a/Darklight Premium/Darklight Premium.vcxproj
+++ b/Darklight Premium/Darklight Premium.vcxproj
@@ -79,6 +79,7 @@
     <ClInclude Include="sdk\interfaces\iglowmanager.h" />
     <ClInclude Include="sdk\interfaces\iinput.h" />
     <ClInclude Include="sdk\interfaces\iinputsystem.h" />
+    <ClInclude Include="sdk\interfaces\ikeyvaluessystem.h" />
     <ClInclude Include="sdk\interfaces\imatchframework.h" />
     <ClInclude Include="sdk\interfaces\ilocalize.h" />
     <ClInclude Include="sdk\interfaces\imaterialsystem.h" />
@@ -155,6 +156,7 @@
     <ClCompile Include="features\triggerbot.cpp" />
     <ClCompile Include="features\visuals.cpp" />
     <ClCompile Include="sdk\convar.cpp" />
+    <ClCompile Include="sdk\datatypes\keyvalues.cpp" />
     <ClCompile Include="sdk\entity.cpp" />
     <ClCompile Include="sdk\hash\crc32.cpp" />
     <ClCompile Include="sdk\hash\md5.cpp" />
@@ -191,21 +193,21 @@
     <ProjectGuid>{F422E214-4936-455B-B8B0-49BC3A106B17}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>qo0_csgo</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>Darklight Premium</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Darklight Premium/Darklight Premium.vcxproj.filters
+++ b/Darklight Premium/Darklight Premium.vcxproj.filters
@@ -380,6 +380,9 @@
     <ClInclude Include="features\ragebot.h">
       <Filter>include</Filter>
     </ClInclude>
+    <ClInclude Include="sdk\interfaces\ikeyvaluessystem.h">
+      <Filter>include</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="features\triggerbot.cpp">
@@ -527,6 +530,9 @@
       <Filter>source</Filter>
     </ClCompile>
     <ClCompile Include="features\ragebot.cpp">
+      <Filter>source</Filter>
+    </ClCompile>
+    <ClCompile Include="sdk\datatypes\keyvalues.cpp">
       <Filter>source</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Darklight Premium/core/gui/controls/slider.cpp
+++ b/Darklight Premium/core/gui/controls/slider.cpp
@@ -56,7 +56,10 @@ void GUI::CONTROLS::Slider(const std::string& szName, int* pValue, int iMin, int
 
 	D::OutlinedRect(m_vOffset.x + 21, m_vOffset.y + 15, iSliderSize, 7, Color(0, 0, 0, CONTROLS::m_flMenuAlpha));
 
-	std::string szValue = std::to_string(*pValue) + szPrefix;
+	/* round it to 3 decimals */
+	std::string szToStr = std::to_string(*pValue);
+	std::string szValue = szToStr.substr(0, szToStr.find(".") + 3);
+
 	if (bHealthPlus && *pValue > 100)
 		szValue = "HP+" + std::to_string(*pValue - 100);
 

--- a/Darklight Premium/core/hooks.cpp
+++ b/Darklight Premium/core/hooks.cpp
@@ -72,6 +72,9 @@ bool H::Setup()
 	if (!DTR::FireGameEvent.Create(MEM::GetVFunc(I::GameEvent, VTABLE::FIREEVENT), &hkFireGameEvent))
 		throw std::runtime_error(_("Failed FireGameEvent"));
 
+	//if (!DTR::AllocKeyValuesMemory.Create(MEM::GetVFunc(I::KeyValuesSystem, VTABLE::ALLOCKEYVALUESMEMORY), &hkAllocKeyValuesMemory))
+	//	return false;
+
 	return true;
 }
 
@@ -659,6 +662,21 @@ bool FASTCALL H::hkIsHLTV(void* pThis, void* edx)
 		return true;
 
 	return oIsHLTV(pThis, edx);
+}
+
+void* __fastcall H::hkAllocKeyValuesMemory(IKeyValuesSystem* thisptr, int edx, int iSize)
+{
+	static auto oAllocKeyValuesMemory = DTR::AllocKeyValuesMemory.GetOriginal<decltype(&hkAllocKeyValuesMemory)>();
+
+	// return addresses of check function
+	// @credits: danielkrupinski
+	static const std::uintptr_t uAllocKeyValuesEngine = MEM::GetAbsoluteAddress(MEM::FindPattern(ENGINE_DLL, _("E8 ? ? ? ? 83 C4 08 84 C0 75 10 FF 75 0C")) + 0x1) + 0x4A;
+	static const std::uintptr_t uAllocKeyValuesClient = MEM::GetAbsoluteAddress(MEM::FindPattern(CLIENT_DLL, _("E8 ? ? ? ? 83 C4 08 84 C0 75 10")) + 0x1) + 0x3E;
+
+	if (const std::uintptr_t uReturnAddress = reinterpret_cast<std::uintptr_t>(_ReturnAddress()); uReturnAddress == uAllocKeyValuesEngine || uReturnAddress == uAllocKeyValuesClient)
+		return nullptr;
+
+	return oAllocKeyValuesMemory(thisptr, edx, iSize);
 }
 
 void FASTCALL H::hkGetColorModulation(void* ecx, void* edx, float* r, float* g, float* b)

--- a/Darklight Premium/core/hooks.cpp
+++ b/Darklight Premium/core/hooks.cpp
@@ -72,8 +72,8 @@ bool H::Setup()
 	if (!DTR::FireGameEvent.Create(MEM::GetVFunc(I::GameEvent, VTABLE::FIREEVENT), &hkFireGameEvent))
 		throw std::runtime_error(_("Failed FireGameEvent"));
 
-	//if (!DTR::AllocKeyValuesMemory.Create(MEM::GetVFunc(I::KeyValuesSystem, VTABLE::ALLOCKEYVALUESMEMORY), &hkAllocKeyValuesMemory))
-	//	return false;
+	if (!DTR::AllocKeyValuesMemory.Create(MEM::GetVFunc(I::KeyValuesSystem, VTABLE::ALLOCKEYVALUESMEMORY), &hkAllocKeyValuesMemory))
+		return false;
 
 	return true;
 }
@@ -492,7 +492,7 @@ void FASTCALL H::hkDrawModel(IStudioRender* thisptr, int edx, DrawModelResults_t
 	CBaseEntity* pLocal = U::GetLocalPlayer();
 	bool bClearOverride = false;
 
-	if (pLocal)
+	if (pLocal; pLocal != nullptr && C::Get<bool>(Vars.bChams))
 		bClearOverride = g_Visuals.Chams(pLocal, pResults, info, pBoneToWorld, flFlexWeights, flFlexDelayedWeights, vecModelOrigin, nFlags);
 
 	oDrawModel(thisptr, edx, pResults, info, pBoneToWorld, flFlexWeights, flFlexDelayedWeights, vecModelOrigin, nFlags);

--- a/Darklight Premium/core/hooks.h
+++ b/Darklight Premium/core/hooks.h
@@ -82,6 +82,9 @@ namespace VTABLE
 		/* netchannel table */
 		SENDNETMSG = 40,
 		SENDDATAGRAM = 46,
+
+		/* keyvaluessystem table */
+		ALLOCKEYVALUESMEMORY = 2,
 	};
 }
 
@@ -127,6 +130,7 @@ namespace DTR
 	inline CDetourHook FireGameEvent;
 	inline CDetourHook Shutdown;
 	inline CDetourHook GetColorModulation;
+	inline CDetourHook AllocKeyValuesMemory;
 }
 
 /*
@@ -336,6 +340,7 @@ namespace H
      
     }
 	*/
+	void* FASTCALL	hkAllocKeyValuesMemory(IKeyValuesSystem* thisptr, int edx, int iSize);
 }
 
 /*

--- a/Darklight Premium/core/interfaces.cpp
+++ b/Darklight Premium/core/interfaces.cpp
@@ -91,6 +91,10 @@ bool I::Setup()
 	if (GlowManager == nullptr)
 		return false;
 
+	KeyValuesSystem = reinterpret_cast<KeyValuesSystemFn>(GetProcAddress(GetModuleHandle(VSTDLIB_DLL), _("KeyValuesSystem")))();
+	if (KeyValuesSystem == nullptr)
+		return false;
+
 	return true;
 }
 

--- a/Darklight Premium/core/interfaces.h
+++ b/Darklight Premium/core/interfaces.h
@@ -43,6 +43,7 @@
 #include "../sdk/interfaces/ivmodelrender.h"
 #include "../sdk/interfaces/ivrenderview.h"
 #include "../sdk/interfaces/iweaponsystem.h"
+#include "../sdk/interfaces/ikeyvaluessystem.h"
 
 class CInterfaceRegister
 {
@@ -110,4 +111,5 @@ namespace I
 	inline IDemoPlayer*				DemoPlayer;
 	inline IWeaponSystem*			WeaponSystem;
 	inline IGlowObjectManager*		GlowManager;
+	inline IKeyValuesSystem* KeyValuesSystem;
 }

--- a/Darklight Premium/features/visuals.cpp
+++ b/Darklight Premium/features/visuals.cpp
@@ -886,10 +886,6 @@ IMaterial* CVisuals::CreateMaterial(std::string_view szName, std::string_view sz
 
 bool CVisuals::Chams(CBaseEntity* pLocal, DrawModelResults_t* pResults, const DrawModelInfo_t& info, matrix3x4_t* pBoneToWorld, float* flFlexWeights, float* flFlexDelayedWeights, const Vector& vecModelOrigin, int nFlags)
 {
-	// seems to crash on CreateMaterial if not checking localplayer? idk too lazy to investigate, inject while in game to avoid crash
-	if (!G::pLocal)
-		return false;
-
 	static auto oDrawModel = DTR::DrawModel.GetOriginal<decltype(&H::hkDrawModel)>();
 	if (!info.pClientEntity)
 		return false;

--- a/Darklight Premium/features/visuals.cpp
+++ b/Darklight Premium/features/visuals.cpp
@@ -876,15 +876,20 @@ IMaterial* CVisuals::CreateMaterial(std::string_view szName, std::string_view sz
 		}}
 	}})#"), fmt::arg(_("shader"), szShader), fmt::arg(_("texture"), szBaseTexture), fmt::arg(_("envmap"), szEnvMap), fmt::arg(_("ignorez"), bIgnorez ? 1 : 0), fmt::arg(_("wireframe"), bWireframe ? 1 : 0), fmt::arg(_("proxies"), szProxies));
 	
-	CKeyValues* pKeyValues = (CKeyValues*)CKeyValues::operator new(sizeof(CKeyValues));
-	pKeyValues->Init(szShader.data());
+	// load to memory
+	CKeyValues* pKeyValues = new CKeyValues(szShader.data());
 	pKeyValues->LoadFromBuffer(szName.data(), szMaterial.c_str());
 
+	// create from buffer
 	return I::MaterialSystem->CreateMaterial(szName.data(), pKeyValues);
 }
 
 bool CVisuals::Chams(CBaseEntity* pLocal, DrawModelResults_t* pResults, const DrawModelInfo_t& info, matrix3x4_t* pBoneToWorld, float* flFlexWeights, float* flFlexDelayedWeights, const Vector& vecModelOrigin, int nFlags)
 {
+	// seems to crash on CreateMaterial if not checking localplayer? idk too lazy to investigate, inject while in game to avoid crash
+	if (!G::pLocal)
+		return false;
+
 	static auto oDrawModel = DTR::DrawModel.GetOriginal<decltype(&H::hkDrawModel)>();
 	if (!info.pClientEntity)
 		return false;

--- a/Darklight Premium/main.cpp
+++ b/Darklight Premium/main.cpp
@@ -81,23 +81,6 @@ DWORD WINAPI OnDllAttach(LPVOID lpParameter)
 		while (GetModuleHandle(SERVERBROWSER_DLL) == nullptr)
 			std::this_thread::sleep_for(200ms);
 
-		long amongus = 0x69690004C201B0;
-		static std::string sig = ("55 8B EC 56 8B F1 33 C0 57 8B 7D 08");
-
-		LPCWSTR modules[]
-		{
-			L"client.dll",
-			L"engine.dll",
-			L"server.dll",
-			L"studiorender.dll",
-			L"materialsystem.dll"
-		};
-
-		// bypass.
-		for (auto base : modules) {
-			WriteProcessMemory(GetCurrentProcess(), find_sig_ida(GetModuleHandleW(base), sig), &amongus, 5, 0);
-		}
-
 		// init interfaces.
 		I::Setup();
 

--- a/Darklight Premium/sdk/datatypes/color.h
+++ b/Darklight Premium/sdk/datatypes/color.h
@@ -40,7 +40,7 @@ public:
 	Color operator+(Color colOther)
 	{
 		return Color(
-			std::min<uint8_t>(255, this->arrColor.at(0) + colOther.r()), 
+			std::min<uint8_t>(255, this->arrColor.at(0) + colOther.r()),
 			std::min<uint8_t>(255, this->arrColor.at(1) + colOther.g()),
 			std::min<uint8_t>(255, this->arrColor.at(2) + colOther.b()));
 	}

--- a/Darklight Premium/sdk/datatypes/keyvalues.cpp
+++ b/Darklight Premium/sdk/datatypes/keyvalues.cpp
@@ -1,0 +1,180 @@
+#include "keyvalues.h"
+
+// used: findpattern, callvfunc, getmodulebasehandle
+#include "../../core/interfaces.h"
+
+CKeyValues::CKeyValues(const char* szKeyName)
+{
+	using InitKeyValuesFn = void(__thiscall*)(void*, const char*);
+	static auto oInitKeyValues = reinterpret_cast<InitKeyValuesFn>(MEM::FindPattern(CLIENT_DLL, _("55 8B EC 51 33 C0 C7 45"))); // @xref: "OldParticleSystem_Destroy"
+	assert(oInitKeyValues != nullptr);
+
+	oInitKeyValues(this, szKeyName);
+}
+
+void* CKeyValues::operator new(std::size_t nAllocSize)
+{
+	return I::KeyValuesSystem->AllocKeyValuesMemory(nAllocSize);
+}
+
+void CKeyValues::operator delete(void* pMemory)
+{
+	I::KeyValuesSystem->FreeKeyValuesMemory(pMemory);
+}
+
+const char* CKeyValues::GetName()
+{
+	return I::KeyValuesSystem->GetStringForSymbol(this->uKeyNameCaseSensitive1 | (this->uKeyNameCaseSensitive2 << 8));
+}
+
+CKeyValues* CKeyValues::FromString(const char* szName, const char* szValue)
+{
+	static auto oFromString = MEM::FindPattern(CLIENT_DLL, _("55 8B EC 81 EC ? ? ? ? 85 D2 53")); // @xref: "#empty#", "#int#"
+	CKeyValues* pKeyValues = nullptr;
+
+	if (oFromString == 0U)
+		return nullptr;
+
+	__asm
+	{
+		push 0
+		mov edx, szValue
+		mov ecx, szName
+		call oFromString
+		add esp, 4
+		mov pKeyValues, eax
+	}
+
+	return pKeyValues;
+}
+
+void CKeyValues::LoadFromBuffer(char const* szResourceName, const char* szBuffer, void* pFileSystem, const char* szPathID, GetSymbolProcFn pfnEvaluateSymbolProc)
+{
+	using LoadFromBufferFn = void(__thiscall*)(void*, const char*, const char*, void*, const char*, void*, void*);
+	static auto oLoadFromBuffer = reinterpret_cast<LoadFromBufferFn>(MEM::FindPattern(CLIENT_DLL, _("55 8B EC 83 E4 F8 83 EC 34 53 8B 5D 0C 89"))); // @xref: "KeyValues::LoadFromBuffer(%s%s%s): Begin"
+	assert(oLoadFromBuffer != nullptr);
+
+	oLoadFromBuffer(this, szResourceName, szBuffer, pFileSystem, szPathID, pfnEvaluateSymbolProc, nullptr);
+}
+
+bool CKeyValues::LoadFromFile(void* pFileSystem, const char* szResourceName, const char* szPathID, GetSymbolProcFn pfnEvaluateSymbolProc)
+{
+	using LoadFromFileFn = bool(__thiscall*)(void*, void*, const char*, const char*, void*);
+	static auto oLoadFromFile = reinterpret_cast<LoadFromFileFn>(MEM::FindPattern(CLIENT_DLL, _("55 8B EC 83 E4 F8 83 EC 14 53 56 8B 75 08 57 FF"))); // @xref: "rb"
+	assert(oLoadFromFile != nullptr);
+
+	return oLoadFromFile(this, pFileSystem, szResourceName, szPathID, pfnEvaluateSymbolProc);
+}
+
+CKeyValues* CKeyValues::FindKey(const char* szKeyName, const bool bCreate)
+{
+	using FindKeyFn = CKeyValues * (__thiscall*)(void*, const char*, bool);
+	static auto oFindKey = reinterpret_cast<FindKeyFn>(MEM::FindPattern(CLIENT_DLL, _("55 8B EC 83 EC 1C 53 8B D9 85 DB")));
+	assert(oFindKey != nullptr);
+
+	return oFindKey(this, szKeyName, bCreate);
+}
+
+int CKeyValues::GetInt(const char* szKeyName, const int iDefaultValue)
+{
+	if (CKeyValues* pSubKey = FindKey(szKeyName, false); pSubKey != nullptr)
+	{
+		switch (pSubKey->chType)
+		{
+		case TYPE_STRING:
+			return std::atoi(pSubKey->szValue);
+		case TYPE_WSTRING:
+			return _wtoi(pSubKey->wszValue);
+		case TYPE_FLOAT:
+			return static_cast<int>(pSubKey->flValue);
+		case TYPE_UINT64:
+			// can't convert, since it would lose data
+			assert(0);
+			return 0;
+		case TYPE_INT:
+		case TYPE_PTR:
+		default:
+			return pSubKey->iValue;
+		}
+	}
+
+	return iDefaultValue;
+}
+
+float CKeyValues::GetFloat(const char* szKeyName, const float flDefaultValue)
+{
+	if (CKeyValues* pSubKey = FindKey(szKeyName, false); pSubKey != nullptr)
+	{
+		switch (pSubKey->chType)
+		{
+		case TYPE_STRING:
+			return static_cast<float>(std::atof(pSubKey->szValue));
+		case TYPE_WSTRING:
+			return std::wcstof(pSubKey->wszValue, nullptr);
+		case TYPE_FLOAT:
+			return pSubKey->flValue;
+		case TYPE_INT:
+			return static_cast<float>(pSubKey->iValue);
+		case TYPE_UINT64:
+			return static_cast<float>(*reinterpret_cast<std::uint64_t*>(pSubKey->szValue));
+		case TYPE_PTR:
+		default:
+			return 0.0f;
+		}
+	}
+
+	return flDefaultValue;
+}
+
+const char* CKeyValues::GetString(const char* szKeyName, const char* szDefaultValue)
+{
+	using GetStringFn = const char* (__thiscall*)(void*, const char*, const char*);
+	static auto oGetString = reinterpret_cast<GetStringFn>(MEM::FindPattern(CLIENT_DLL, _("55 8B EC 83 E4 C0 81 EC ? ? ? ? 53 8B 5D 08")));
+	assert(oGetString != nullptr);
+
+	return oGetString(this, szKeyName, szDefaultValue);
+}
+
+void CKeyValues::SetString(const char* szKeyName, const char* szStringValue)
+{
+	CKeyValues* pSubKey = FindKey(szKeyName, true);
+
+	if (pSubKey == nullptr)
+		return;
+
+	using SetStringFn = void(__thiscall*)(void*, const char*);
+	static auto oSetString = reinterpret_cast<SetStringFn>(MEM::FindPattern(CLIENT_DLL, _("55 8B EC A1 ? ? ? ? 53 56 57 8B F9 8B 08 8B 01")));
+	assert(oSetString != nullptr);
+
+	oSetString(pSubKey, szStringValue);
+}
+
+void CKeyValues::SetInt(const char* szKeyName, const int iValue)
+{
+	CKeyValues* pSubKey = FindKey(szKeyName, true);
+
+	if (pSubKey == nullptr)
+		return;
+
+	pSubKey->iValue = iValue;
+	pSubKey->chType = TYPE_INT;
+}
+
+void CKeyValues::SetUint64(const char* szKeyName, const int nLowValue, const int nHighValue)
+{
+	CKeyValues* pSubKey = FindKey(szKeyName, true);
+
+	if (pSubKey == nullptr)
+		return;
+
+	// delete the old value
+	delete[] pSubKey->szValue;
+
+	// make sure we're not storing the WSTRING - as we're converting over to STRING
+	delete[] pSubKey->wszValue;
+	pSubKey->wszValue = nullptr;
+
+	pSubKey->szValue = new char[sizeof(std::uint64_t)];
+	*reinterpret_cast<std::uint64_t*>(pSubKey->szValue) = static_cast<std::uint64_t>(nHighValue) << 32ULL | nLowValue;
+	pSubKey->chType = TYPE_UINT64;
+}

--- a/Darklight Premium/sdk/interfaces/iinput.h
+++ b/Darklight Premium/sdk/interfaces/iinput.h
@@ -7,17 +7,17 @@
 class IInput
 {
 public:
-	std::byte			pad0[0xC];				//0x00
-	bool				bTrackIRAvailable;		//0x0C
-	bool				bMouseInitialized;		//0x0D
-	bool				bMouseActive;			//0x0E
-	std::byte			pad1[0x9E];				//0x0F
-	bool				bCameraInThirdPerson;	//0xAD
-	std::byte			pad2[0x2];				//0xAE
-	Vector				vecCameraOffset;		//0xB0
-	std::byte			pad3[0x38];				//0xBC
-	CUserCmd*			pCommands;				//0xF4
-	CVerifiedUserCmd*	pVerifiedCommands;		//0xF8
+	std::byte			pad0[0xC];				// 0x00
+	bool				bTrackIRAvailable;		// 0x0C
+	bool				bMouseInitialized;		// 0x0D
+	bool				bMouseActive;			// 0x0E
+	std::byte			pad1[0x9A];				// 0x0F
+	bool				bCameraInThirdPerson;	// 0xA9
+	std::byte			pad2[0x2];				// 0xAA
+	Vector				vecCameraOffset;		// 0xAC
+	std::byte			pad3[0x38];				// 0xB8
+	CUserCmd*			pCommands;				// 0xF0
+	CVerifiedUserCmd*	pVerifiedCommands;		// 0xF4
 
 	CUserCmd* GetUserCmd(int nSequenceNumber)
 	{

--- a/Darklight Premium/sdk/interfaces/ikeyvaluessystem.h
+++ b/Darklight Premium/sdk/interfaces/ikeyvaluessystem.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#define INVALID_KEY_SYMBOL (-1)
+using HKeySymbol = int;
+
+class IKeyValuesSystem
+{
+public:
+	virtual void RegisterSizeofKeyValues(int iSize) = 0;
+private:
+	virtual void function0() = 0;
+public:
+	virtual void* AllocKeyValuesMemory(int iSize) = 0;
+	virtual void FreeKeyValuesMemory(void* pMemory) = 0;
+	virtual HKeySymbol GetSymbolForString(const char* szName, bool bCreate = true) = 0;
+	virtual const char* GetStringForSymbol(HKeySymbol hSymbol) = 0;
+	virtual void AddKeyValuesToMemoryLeakList(void* pMemory, HKeySymbol hSymbolName) = 0;
+	virtual void RemoveKeyValuesFromMemoryLeakList(void* pMemory) = 0;
+	virtual void SetKeyValuesExpressionSymbol(const char* szName, bool bValue) = 0;
+	virtual bool GetKeyValuesExpressionSymbol(const char* szName) = 0;
+	virtual HKeySymbol GetSymbolForStringCaseSensitive(HKeySymbol& hCaseInsensitiveSymbol, const char* szName, bool bCreate = true) = 0;
+};
+
+using KeyValuesSystemFn = IKeyValuesSystem * (__cdecl*)();

--- a/Darklight Premium/utilities/draw.h
+++ b/Darklight Premium/utilities/draw.h
@@ -27,12 +27,7 @@ namespace D
 	inline unsigned long uMenuSliderFont[5];
 	inline unsigned long uTrebuchetMS[5];
 
-	inline int ScaleDPI(int i)
-	{
-		return (i * (1.0f + (0.25f * G::iDPIScale)));
-	}
-
-	inline int ScaleDPI(int i, int x)
+	inline int ScaleDPI(int i, int x = G::iDPIScale)
 	{
 		return (i * (1.0f + (0.25f * x)));
 	}

--- a/Darklight Premium/utilities/memory.h
+++ b/Darklight Premium/utilities/memory.h
@@ -120,4 +120,9 @@ namespace MEM
 		using VirtualFn = T(__thiscall*)(void*, decltype(argList)...);
 		return (*(VirtualFn**)thisptr)[nIndex](thisptr, argList...);
 	}
+
+	inline std::uintptr_t GetAbsoluteAddress(const std::uintptr_t uRelativeAddress)
+	{
+		return uRelativeAddress + 0x4 + *reinterpret_cast<std::int32_t*>(uRelativeAddress);
+	}
 }


### PR DESCRIPTION
-Remove that WriteProc in main.cpp since its outdated and causing crash
-Pasted hkAllocKeyValuesMemory from https://github.com/rollraw/qo0-base/blob/92a3b3aefa220da941c3feee387702c772d1af82/base/core/hooks.cpp#L55
-Pasted the Interfaces ( also from @rollraw )
-Some crash happened when loading into maps ( I'm so lazy but my debugger said at the CKeyValues so I just add the check for local player != nullptr without testing again )

I used vs2022 so its v143 not v141 so yea lol 

might forgor smthing but idk its 4am